### PR TITLE
Add Sat and Sun to timetable view

### DIFF
--- a/src/components/TimeTable/ScheduleBlocks.tsx
+++ b/src/components/TimeTable/ScheduleBlocks.tsx
@@ -16,6 +16,8 @@ const ScheduleBlocks = () => {
         <Weekday day={2} />
         <Weekday day={3} />
         <Weekday day={4} />
+        <Weekday day={5} />
+        <Weekday day={6} />
       </div>
     </div>
   );

--- a/src/components/TimeTable/TimeTableCourse.tsx
+++ b/src/components/TimeTable/TimeTableCourse.tsx
@@ -32,7 +32,7 @@ const TimeTableCourse = ({
   return (
     <div
       style={{
-        width: "135px",
+        width: "95px",
         height: (12.5 * timeIn15MinBlocks).toString() + "px",
         backgroundColor: "#54008c",
         textAlign: "center",

--- a/src/components/TimeTable/TimeTableCourseBuilder.tsx
+++ b/src/components/TimeTable/TimeTableCourseBuilder.tsx
@@ -24,7 +24,7 @@ const TimeTableCourseBuilder = ({ indices, howMany }) => {
       type: "no",
     },
   ]);
-  const week = [142, 282, 422, 562, 702];
+  const week = [142, 242, 342, 442, 542, 642, 742];
 
   useEffect(() => {
     // const elementsUpdated = elements;

--- a/src/components/TimeTable/Weekday.tsx
+++ b/src/components/TimeTable/Weekday.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const weekdays = ["Mon", "Tue", "Wed", "Thurs", "Fri"];
+const weekdays = ["Mon", "Tue", "Wed", "Thurs", "Fri", "Sat", "Sun"];
 
 const Weekday = ({ day }) => {
   let elements: JSX.Element[] = [];


### PR DESCRIPTION
While infrequent some courses have times on Saturday and possibly Sunday such as
> CS-UY 4793-B Computer Networking
> Reg #: 17279
> Timings: 150 minutes, Sat 11:00-13:30.

Attempting to display this course on the timetable will crash the page:

![image](https://user-images.githubusercontent.com/48587962/142575259-3b746e33-dbae-428a-b4f1-a753936a37fc.png)

This PR adds Saturday and Sunday to the timetable view and modifies some of the UI widths so the boxes fit the narrower 7 columns.

![image](https://user-images.githubusercontent.com/48587962/142577019-43042a42-d280-4e1e-a3c7-450baa8155d8.png)
